### PR TITLE
feat: add additional return endpoints

### DIFF
--- a/lib/malomo/return.ex
+++ b/lib/malomo/return.ex
@@ -2,7 +2,7 @@ defmodule Malomo.Return do
   alias Malomo.Operation
 
   @doc """
-  Create a return.
+  Create a Return.
   """
   @spec create(Keyword.t()) :: Operation.t()
   def create(opts) do
@@ -10,5 +10,37 @@ defmodule Malomo.Return do
     |> Map.put(:method, :post)
     |> Map.put(:params, opts)
     |> Map.put(:path, "/returns")
+  end
+
+  @doc """
+  Retrieve a Return.
+  """
+  @spec get(binary()) :: Operation.t()
+  def get(id) do
+    %Operation{}
+    |> Map.put(:method, :get)
+    |> Map.put(:path, "/returns/#{id}")
+  end
+
+  @doc """
+  Retrieve a Return by a third-party alternate id.
+  """
+  @spec get_by_alternate_id(binary()) :: Operation.t()
+  def get_by_alternate_id(alternate_id) do
+    %Operation{}
+    |> Map.put(:method, :get)
+    |> Map.put(:params, [alternate_id: alternate_id])
+    |> Map.put(:path, "/returns")
+  end
+
+  @doc """
+  Update a Return.
+  """
+  @spec update(binary(), Keyword.t()) :: Operation.t()
+  def update(id, opts) do
+    %Operation{}
+    |> Map.put(:method, :put)
+    |> Map.put(:params, opts)
+    |> Map.put(:path, "/returns/#{id}")
   end
 end

--- a/test/malomo/return_test.exs
+++ b/test/malomo/return_test.exs
@@ -5,11 +5,45 @@ defmodule Malomo.ReturnTest do
   alias Malomo.Return
 
   test "create/1" do
-    expected = %Operation{}
-    expected = Map.put(expected, :method, :post)
-    expected = Map.put(expected, :params, [p1: "v"])
-    expected = Map.put(expected, :path, "/returns")
+    expected = %Operation{
+      method: :post,
+      params: [p1: "v"],
+      path: "/returns"
+    }
 
     assert expected == Return.create(p1: "v")
+  end
+
+  test "get/1" do
+    expected = %Operation{
+      method: :get,
+      params: [],
+      path: "/returns/0d639a29-feeb-338f-bc82-e578602e4a02"
+
+    }
+
+    assert expected == Return.get("0d639a29-feeb-338f-bc82-e578602e4a02")
+  end
+
+  test "get_by_alternate_id/1" do
+    expected = %Operation{
+      method: :get,
+      params: [alternate_id: "0d639a29-feeb-338f-bc82-e578602e4a02"],
+      path: "/returns"
+
+    }
+
+    assert expected == Return.get_by_alternate_id("0d639a29-feeb-338f-bc82-e578602e4a02")
+  end
+
+  test "update/2" do
+    expected = %Operation{
+      method: :put,
+      params: [p1: "v"],
+      path: "/returns/0d639a29-feeb-338f-bc82-e578602e4a02"
+
+    }
+
+    assert expected == Return.update("0d639a29-feeb-338f-bc82-e578602e4a02", p1: "v")
   end
 end


### PR DESCRIPTION
# Motivation
Support for new Return endpoints

# Changes
- Added `GET /returns/{id}`
- Added `GET /returns/?alternate_id={alternate_id}`
- Added `PUT /returns/{id}`